### PR TITLE
Enable building on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 TARGET = lfs
 
-CC = gcc
+OS := $(shell uname -s)
+
+ifeq ($(OS), FreeBSD)
+	CC = cc
+else
+	CC = gcc
+endif
+
 AR = ar
 SIZE = size
 
@@ -24,6 +31,11 @@ CFLAGS += -D_XOPEN_SOURCE=700
 
 LFLAGS += -lfuse
 
+ifeq ($(OS), FreeBSD)
+	CFLAGS += -I /usr/local/include
+	CFLAGS += -D __BSD_VISIBLE
+	LFLAGS += -L /usr/local/lib
+endif
 
 all: $(TARGET)
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,7 @@ TARGET = lfs
 
 OS := $(shell uname -s)
 
-ifeq ($(OS), FreeBSD)
-	CC = cc
-else
-	CC = gcc
-endif
-
+CC = cc
 AR = ar
 SIZE = size
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A FUSE wrapper that puts the littlefs in user-space.
 **FUSE** - https://github.com/libfuse/libfuse  
 **littlefs** - https://github.com/geky/littlefs  
 
-This project allows you to mount littlefs directly in a Linux or FreeBSD machine.
+This project allows you to mount littlefs directly in a host PC.
 This allows you to easily debug an embedded system using littlefs on
 removable storage, or even debug littlefs itself, since the block device
 can be viewed in a hex-editor simultaneously.
@@ -15,70 +15,45 @@ it can be compiled into a simple user program without kernel modifications.
 This comes with a performance penalty, but works well for the littlefs,
 since littlefs is intended for embedded systems.
 
-## Usage
+Currently littlefs-fuse has been tested on the following OSs:
+- [Linux](#usage-on-linux)
+- [FreeBSD](#usage-on-freebsd)
 
-littlefs-fuse requires FUSE version 2.6, you can find your FUSE version with:  
-Linux:
+## Usage on Linux
+
+littlefs-fuse requires FUSE version 2.6 or higher, you can find your FUSE
+version with:
 ``` bash
 fusermount -V
 ```
-FreeBSD:
-``` bash
-pkg info fusefs-libs | grep Version
-```
 
-Once you have cloned littlefs-fuse, you can compile the program with make:  
-Linux:
+Once you have cloned littlefs-fuse, you can compile the program with make:
 ``` bash
 make
-```
-FreeBSD:
-``` bash
-gmake
 ```
 
 This should have built the `lfs` program in the top-level directory.
 
 From here we will need a block device. If you don't have removable storage
-handy, you can use a file-backed block device with Linux's loop devices:  
-Linux:
+handy, you can use a file-backed block device with Linux's loop devices:
 ``` bash
 sudo chmod a+rw /dev/loop0                  # make loop device user accessible
 dd if=/dev/zero of=image bs=512 count=2048  # create a 1MB image
 losetup /dev/loop0 image                    # attach the loop device
 ```
 
-FreeBSD:
-``` bash
-dd if=/dev/zero of=imageBSD bs=1m count=1   # create a 1 MB image
-sudo mdconfig -at vnode -f image            # attach the loop device
-sudo chmod 666 /dev/mdX                     # make loop device user accessible,
-                                            # where mdX is device created with mdconfig command
-```
-
 littlefs-fuse has two modes of operation, formatting and mounting.
 
 To format a block device, pass the `--format` flag. Note! This will erase any
-data on the block device!  
-Linux:
+data on the block device!
 ``` bash
 ./lfs --format /dev/loop0
 ```
-FreeBSD:
-``` bash
-./lfs --format /dev/md0
-```
 
-To mount, run littlefs-fuse with a block device and a mountpoint:  
-Linux:
+To mount, run littlefs-fuse with a block device and a mountpoint:
 ``` bash
 mkdir mount
 ./lfs /dev/loop0 mount
-```
-FreeBSD:
-``` bash
-mkdir mount
-./lfs /dev/md0 mount
 ```
 
 Once mounted, the littlefs filesystem will be accessible through the
@@ -91,14 +66,61 @@ ls
 cat hi.txt
 ```
 
-After you done with using littlefs filesystem, you can unmount it and detach the loop device:  
-Linux:
+After using littlefs, you can unmount and detach the loop device:
 ``` bash
 cd ..
 umount mount
 sudo losetup -d /dev/loop0
 ```
-FreeBSD:
+
+## Usage on FreeBSD
+
+littlefs-fuse requires FUSE version 2.6 or higher, you can find your FUSE
+version with:
+``` bash
+pkg info fusefs-libs | grep Version
+```
+
+Once you have cloned littlefs-fuse, you can compile the program with make:
+``` bash
+gmake
+```
+
+This should have built the `lfs` program in the top-level directory.
+
+From here we will need a block device. If you don't have removable storage
+handy, you can use a file-backed block device with FreeBSD's loop devices:
+``` bash
+dd if=/dev/zero of=imageBSD bs=1m count=1   # create a 1 MB image
+sudo mdconfig -at vnode -f image            # attach the loop device
+sudo chmod 666 /dev/mdX                     # make loop device user accessible,
+                                            # where mdX is device created with mdconfig command
+```
+
+littlefs-fuse has two modes of operation, formatting and mounting.
+
+To format a block device, pass the `--format` flag. Note! This will erase any
+data on the block device!
+``` bash
+./lfs --format /dev/md0
+```
+
+To mount, run littlefs-fuse with a block device and a mountpoint:
+``` bash
+mkdir mount
+./lfs /dev/md0 mount
+```
+
+Once mounted, the littlefs filesystem will be accessible through the
+mountpoint. You can now use the littlefs like you would any other filesystem:
+``` bash
+cd mount
+echo "hello" > hi.txt
+ls
+cat hi.txt
+```
+
+After using littlefs, you can unmount and detach the loop device:
 ``` bash
 cd ..
 umount mount

--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -10,9 +10,15 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdint.h>
+#include <assert.h>
+#if !defined(__FreeBSD__)
 #include <stropts.h>
 #include <linux/fs.h>
-#include <assert.h>
+#elif defined(__FreeBSD__)
+#define BLKSSZGET DIOCGSECTORSIZE
+#define BLKGETSIZE DIOCGMEDIASIZE
+#include <sys/disk.h>
+#endif
 
 
 // Block device wrapper for user-space block devices


### PR DESCRIPTION
Here is a patch which enables building and using LittleFS on FreeBSD.
I have tested it on Debian VM and FreeBSD 11.1-RELEASE.
Image created on Linux is usable on FreeBSD and vice-versa.
Tested with txt and binary files, md5 checksum of the files is OK under both OSes.